### PR TITLE
Show rx is as a dependency in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ RxJS utilities for Redux. Includes
 - A utility to create a sequence of states from a Redux store.
 
 ```js
-npm install --save redux-rx
+npm install --save redux-rx rx
 ```
 
 ## Usage


### PR DESCRIPTION
As I said wrote in https://github.com/acdlite/react-rx-component/pull/9, redux-rx will fail without rx installed because react-rx-component depends on it. 
