### PR TITLE
Add homepage and bugs url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,11 @@
     "flux"
   ],
   "author": "Andrew Clark <acdlite@me.com>",
+  "homepage": "https://github.com/acdlite/redux-rx",
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/acdlite/redux-rx/issues"
+  },
   "devDependencies": {
     "babel": "^5.6.14",
     "babel-core": "^5.6.15",


### PR DESCRIPTION
I couldn't click through from the npm page :disappointed: 

![image](https://cloud.githubusercontent.com/assets/399469/9211122/ddb7cd64-4034-11e5-87cf-4f61ff2d78f2.png)
