### PR TITLE
 does not work with redux 2+

### DIFF
--- a/src/observableMiddleware.js
+++ b/src/observableMiddleware.js
@@ -2,7 +2,7 @@ import { isFSA } from 'flux-standard-action';
 import isObservable from './isObservable';
 
 export default function observableMiddleware() {
-  return next => action => {
+  return store => next => action => {
     if (!isFSA(action)) {
       return isObservable(action)
         ? action.doOnNext(next)


### PR DESCRIPTION
according to the docs here :http://redux.js.org/docs/advanced/Middleware.html
a middleware is a function with this signature:

`const middleWare = store => next => action => {
   return next(action)
}`

the current implementation is missing the first function which receives store.
so i was getting an error "next is not a function"

this fixes it
